### PR TITLE
feat: Add createMilestone tool

### DIFF
--- a/pkg/github/__toolsnaps__/create_milestone.snap
+++ b/pkg/github/__toolsnaps__/create_milestone.snap
@@ -1,0 +1,46 @@
+{
+  "annotations": {
+    "title": "Create new milestone",
+    "readOnlyHint": false
+  },
+  "description": "Create a new milestone in a GitHub repository.",
+  "inputSchema": {
+    "properties": {
+      "description": {
+        "description": "Milestone description",
+        "type": "string"
+      },
+      "due_on": {
+        "description": "Milestone due date in ISO 8601 format (YYYY-MM-DDTHH:MM:SSZ)",
+        "type": "string"
+      },
+      "owner": {
+        "description": "Repository owner",
+        "type": "string"
+      },
+      "repo": {
+        "description": "Repository name",
+        "type": "string"
+      },
+      "state": {
+        "description": "Milestone state",
+        "enum": [
+          "open",
+          "closed"
+        ],
+        "type": "string"
+      },
+      "title": {
+        "description": "Milestone title",
+        "type": "string"
+      }
+    },
+    "required": [
+      "owner",
+      "repo",
+      "title"
+    ],
+    "type": "object"
+  },
+  "name": "create_milestone"
+}

--- a/pkg/github/issues.go
+++ b/pkg/github/issues.go
@@ -206,6 +206,106 @@ func GetIssue(getClient GetClientFn, t translations.TranslationHelperFunc) (tool
 		}
 }
 
+// CreateMilestone creates a tool to create a new milestone in a GitHub repository.
+func CreateMilestone(getClient GetClientFn, t translations.TranslationHelperFunc) (tool mcp.Tool, handler server.ToolHandlerFunc) {
+	return mcp.NewTool("create_milestone",
+			mcp.WithDescription(t("TOOL_CREATE_MILESTONE_DESCRIPTION", "Create a new milestone in a GitHub repository.")),
+			mcp.WithToolAnnotation(mcp.ToolAnnotation{
+				Title:        t("TOOL_CREATE_MILESTONE_USER_TITLE", "Create new milestone"),
+				ReadOnlyHint: ToBoolPtr(false),
+			}),
+			mcp.WithString("owner",
+				mcp.Required(),
+				mcp.Description("Repository owner"),
+			),
+			mcp.WithString("repo",
+				mcp.Required(),
+				mcp.Description("Repository name"),
+			),
+			mcp.WithString("title",
+				mcp.Required(),
+				mcp.Description("Milestone title"),
+			),
+			mcp.WithString("state",
+				mcp.Description("Milestone state"),
+				mcp.Enum("open", "closed"),
+			),
+			mcp.WithString("description",
+				mcp.Description("Milestone description"),
+			),
+			mcp.WithString("due_on",
+				mcp.Description("Milestone due date in ISO 8601 format (YYYY-MM-DDTHH:MM:SSZ)"),
+			),
+		),
+		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			owner, err := RequiredParam[string](request, "owner")
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+			repo, err := RequiredParam[string](request, "repo")
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+			title, err := RequiredParam[string](request, "title")
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+
+			// Optional parameters
+			state, err := OptionalParam[string](request, "state")
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+			description, err := OptionalParam[string](request, "description")
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+			dueOn, err := OptionalParam[string](request, "due_on")
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+
+			milestoneRequest := &github.Milestone{
+				Title:       github.Ptr(title),
+				State:       github.Ptr(state),
+				Description: github.Ptr(description),
+			}
+
+			if dueOn != "" {
+				dueOnTime, err := time.Parse(time.RFC3339, dueOn)
+				if err != nil {
+					return mcp.NewToolResultError(fmt.Sprintf("invalid due_on format: %v", err)), nil
+				}
+				milestoneRequest.DueOn = &github.Timestamp{Time: dueOnTime}
+			}
+
+			client, err := getClient(ctx)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get GitHub client: %w", err)
+			}
+			milestone, resp, err := client.Issues.CreateMilestone(ctx, owner, repo, milestoneRequest)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create milestone: %w", err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			if resp.StatusCode != http.StatusCreated {
+				body, err := io.ReadAll(resp.Body)
+				if err != nil {
+					return nil, fmt.Errorf("failed to read response body: %w", err)
+				}
+				return mcp.NewToolResultError(fmt.Sprintf("failed to create milestone: %s", string(body))), nil
+			}
+
+			r, err := json.Marshal(milestone)
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal response: %w", err)
+			}
+
+			return mcp.NewToolResultText(string(r)), nil
+		}
+}
+
 // ListIssueTypes creates a tool to list defined issue types for an organization. This can be used to understand supported issue type values for creating or updating issues.
 func ListIssueTypes(getClient GetClientFn, t translations.TranslationHelperFunc) (tool mcp.Tool, handler server.ToolHandlerFunc) {
 

--- a/pkg/github/tools.go
+++ b/pkg/github/tools.go
@@ -61,6 +61,7 @@ func DefaultToolsetGroup(readOnly bool, getClient GetClientFn, getGQLClient GetG
 		).
 		AddWriteTools(
 			toolsets.NewServerTool(CreateIssue(getClient, t)),
+			toolsets.NewServerTool(CreateMilestone(getClient, t)),
 			toolsets.NewServerTool(AddIssueComment(getClient, t)),
 			toolsets.NewServerTool(UpdateIssue(getClient, t)),
 			toolsets.NewServerTool(AssignCopilotToIssue(getGQLClient, t)),


### PR DESCRIPTION
This commit adds a new mcp tool command `createMilestone` to create a new milestone in a GitHub repository.

The tool is added to the `issues` toolset and includes the following parameters:
- owner
- repo
- title
- state
- description
- due_on

A test has been added to verify the functionality of the new tool.

<!--
    Thank you for contributing to GitHub MCP Server!
    Please reference an existing issue: `Closes #NUMBER`

    Screenshots or videos of changed behavior is incredibly helpful and always appreciated.
    Consider addressing the following:
    - Tradeoffs: List tradeoffs you made to take on or pay down tech debt.
    - Alternatives: Describe alternative approaches you considered and why you discarded them.
-->

Closes:
